### PR TITLE
modified middleware to support optional trying of JSON.parse

### DIFF
--- a/app/helpers/middleware.js
+++ b/app/helpers/middleware.js
@@ -4,20 +4,28 @@ var SimpleResponse = require('./misc').SimpleResponse;
 
 module.exports = {
     // forces an endpoint to use json
-    forceJSON: function(req, res, next) {
-        // force application/json content-type
-        if(!req.headers || !req.headers['content-type'] || req.headers['content-type'].toLowerCase() !== 'application/json') {
-            return res.status(400).json(new SimpleResponse('error', 'content-type must be application/json'));
-        }
+    // tryParse:bool - if set to true, we'll test for valid json with JSON.parse(). default: false
+    forceJSON: function(tryParse) {
+        tryParse = tryParse || false;
 
-        // force json in the body
-        try {
-            JSON.parse(req.body);
-        } catch (e) {
-            return res.status(400).json(new SimpleResponse('error', 'body must be valid json'));
-        }
+        return function(req, res, next) {
+            // force application/json content-type
+            if(!req.headers || !req.headers['content-type'] || req.headers['content-type'].toLowerCase() !== 'application/json') {
+                return res.status(400).json(new SimpleResponse('error', 'content-type must be application/json'));
+            }
 
-        return next();
+            // force json in the body
+            if (tryParse) {
+                try {
+                    JSON.parse(req.body);
+                } catch (e) {
+                    // respond with actual error, since a) this is user content
+                    // and b) it's better to not swallow the contents of this error
+                    return res.status(400).json(new SimpleResponse('error', e.message));
+                }
+            }
+            return next();
+        };
     },
     isLoggedIn: function(req, res, next) {
         if (req.isAuthenticated()) {

--- a/app/routes/api.js
+++ b/app/routes/api.js
@@ -10,7 +10,7 @@ var SimpleResponse = require('../helpers/misc').SimpleResponse;
 
 module.exports = function(passport) {
     // logs ======================================================================
-    router.post('/logs/', passport.authenticate('bearer', { session: false }), middleware.forceJSON, function(req, res) {
+    router.post('/logs', passport.authenticate('bearer', { session: false }), middleware.forceJSON(), function(req, res) {
         // make sure logs are present in the request
         if(!req.body.logs) {
             return res.status(400).json(new SimpleResponse('error', 'invalid body content'));


### PR DESCRIPTION
this way, we can avoid doing the heavy `JSON.parse()` operation when we don't need it, but we still want to force the `content-type` header to `application/json`
